### PR TITLE
Disable the demo course and account creation for scalable edxapp vms

### DIFF
--- a/playbooks/roles/mysql/files/edxapp.sql
+++ b/playbooks/roles/mysql/files/edxapp.sql
@@ -1,8 +1,3 @@
-UPDATE auth_user SET is_active=False where username="staff";
-UPDATE auth_user SET is_active=False where username="honor";
-UPDATE auth_user SET is_active=False where username="audit";
-UPDATE auth_user SET is_active=False where username="verified";
-
 /* 
   Adding unique constraint on the email column of auth_user table
   so that multiple accounts with same e-mail address cannot be created

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -160,7 +160,7 @@ update_stamp_jb() {
 
 update_stamp_vmss() {
   # edx playbooks - sandbox with remote mongo/mysql
-  $ANSIBLE_PLAYBOOK -i localhost, -c local -e@$OXA_PLAYBOOK_CONFIG edx_sandbox.yml -e "migrate_db=no"
+  $ANSIBLE_PLAYBOOK -i localhost, -c local -e@$OXA_PLAYBOOK_CONFIG edx_sandbox.yml -e "migrate_db=no" --skip-tags=demo_course
   exit_on_error "Execution of edX sandbox playbook failed"
   
   # oxa playbooks


### PR DESCRIPTION
I already submitted a change for microsoft/edx-configuration/playbooks/edx_sandbox.yml that is used for edxapp VMs in VMSS. We added tag for demo role like that
 - { role: 'demo', tags: [ 'demo_course' ] }

In oxa-tools we are making two changes to skip demo role from edxapp VM in scalable version:
1) in bootstrap.sh we added "--skip-tags=demo_course" option so that it doesn't run the demo role and skips it. So default course and accounts will not be created. But if we want we can run scalable automation without this option and then we can have demo role applied. 

2) Secondly we removed the SQL statements that deactives for default accounts which are staff, honor, audit, verified. We are skipping the demo role in scalable setup from ansible commandline so the default course and accounts will not be created. In fullstack they will be created and no need to deactivate them

@Microsoft/lex 