### PR TITLE
Probe changes from @btelnes

### DIFF
--- a/templates/stamp/node-vmss.json
+++ b/templates/stamp/node-vmss.json
@@ -211,10 +211,11 @@
                     {
                         "name": "[parameters('networkSettings').loadbalancerSettings.lbProbeLMSName]",
                         "properties": {
-                            "protocol": "tcp",
+                            "protocol": "http",
                             "port": 80,
+                            "requestPath": "/heartbeat",
                             "intervalInSeconds": "5",
-                            "numberOfProbes": "2"
+                            "numberOfProbes": "4"
                         }
                     },
                     {
@@ -223,16 +224,17 @@
                             "protocol": "tcp",
                             "port": 443,
                             "intervalInSeconds": "5",
-                            "numberOfProbes": "2"
+                            "numberOfProbes": "4"
                         }
                     },
                     {
                         "name": "[parameters('networkSettings').loadbalancerSettings.lbProbeCMSName]",
                         "properties": {
-                            "protocol": "tcp",
+                            "protocol": "http",
                             "port": 18010,
+                            "requestPath": "/heartbeat",
                             "intervalInSeconds": "5",
-                            "numberOfProbes": "2"
+                            "numberOfProbes": "4"
                         }
                     },
                     {
@@ -241,7 +243,7 @@
                             "protocol": "tcp",
                             "port": 48010,
                             "intervalInSeconds": "5",
-                            "numberOfProbes": "2"
+                            "numberOfProbes": "4"
                         }
                     }
                 ]


### PR DESCRIPTION
@eltoncarr @btelnes 

These are remaining changes from aac5440d5d8fb80d9ff8fec939e6a73794fb2abb that aren't in the eltonc branch. One other difference is that @btelnes had LB CMS SSL rule as 48010->48010, whereas @eltoncarr had 443->48010. We should keep 443, but likely need to fix nginx conf redirect for CMS as 18010->443 assuming redirect goes through LB.