### PR TITLE
Changing the e-mail adrresses with microsoftlearning- prefix and removing openedx

### DIFF
--- a/config/server-vars.yml
+++ b/config/server-vars.yml
@@ -83,16 +83,16 @@ GRADES_DOWNLOAD:
   CONTAINER: "reports"
 
 # Configure email addresses
-EDXAPP_BUGS_EMAIL: "bugs@openedx.microsoft.com"
-EDXAPP_BULK_EMAIL_DEFAULT_FROM_EMAIL: "no-reply@openedx.microsoft.com"
-EDXAPP_CONTACT_EMAIL: "info@openedx.microsoft.com"
-EDXAPP_DEFAULT_FEEDBACK_EMAIL: "feedback@openedx.microsoft.com"
-EDXAPP_DEFAULT_FROM_EMAIL: "registration@openedx.microsoft.com"
-EDXAPP_PAYMENT_SUPPORT_EMAIL: "billing@openedx.microsoft.com"
-EDXAPP_PRESS_EMAIL: "press@openedx.microsoft.com"
+EDXAPP_BUGS_EMAIL: "microsoftlearning-bugs@microsoft.com"
+EDXAPP_BULK_EMAIL_DEFAULT_FROM_EMAIL: "microsoftlearning-noreply@microsoft.com"
+EDXAPP_CONTACT_EMAIL: "microsoftlearning-info@microsoft.com"
+EDXAPP_DEFAULT_FEEDBACK_EMAIL: "microsoftlearning-feedback@microsoft.com"
+EDXAPP_DEFAULT_FROM_EMAIL: "microsoftlearning-registration@microsoft.com"
+EDXAPP_PAYMENT_SUPPORT_EMAIL: "microsoftlearning-billing@microsoft.com"
+EDXAPP_PRESS_EMAIL: "microsoftlearning-press@microsoft.com"
 EDXAPP_DEFAULT_SERVER_EMAIL: "%%PLATFORM_EMAIL%%"
-EDXAPP_TECH_SUPPORT_EMAIL: "technical@openedx.microsoft.com"
-EDXAPP_UNIVERSITY_EMAIL: "university@openedx.microsoft.com"
+EDXAPP_TECH_SUPPORT_EMAIL: "microsoftlearning-technical@microsoft.com"
+EDXAPP_UNIVERSITY_EMAIL: "microsoftlearning-university@microsoft.com"
 
 EDXAPP_LTI_USER_EMAIL_DOMAIN: "lti.openedx.microsoft.com"
 


### PR DESCRIPTION
Changing the email address by prefixing with "microsoftlearning-" and removing the openedx from e-mail address dns name so that e-mails sent from platform don't end up in junk folder.