### PR TITLE
Fixed the two letter code of Cuba. It must be CU not CB.

### DIFF
--- a/config/countries.yml
+++ b/config/countries.yml
@@ -6,7 +6,7 @@ EDXAPP_COUNTRIES_OVERRIDE:
   BN: "Brunei"
   CD: "Congo (DRC)"
   IR: null
-  CB: null
+  CU: null
   FK: "Falkland Islands"
   VA: null
   HK: "Hong Kong SAR"


### PR DESCRIPTION
Fixed the two letter code of Cuba. It must be CU not CB.