### PR TITLE
Adding ENABLE_VIDEO_UPLOAD_PIPELINE under FEATURES section.

### DIFF
--- a/config/server-vars.yml
+++ b/config/server-vars.yml
@@ -71,6 +71,7 @@ EDXAPP_FEATURES:
   CERTIFICATES_ENABLED: true
   CERTIFICATES_HTML_VIEW: true
   ENABLE_GRADE_DOWNLOADS: true
+  ENABLE_VIDEO_UPLOAD_PIPELINE: true
 
 # storage uploads
 EDXAPP_DEFAULT_FILE_STORAGE: "storages.backends.azure_storage.AzureStorage"


### PR DESCRIPTION
Adding ENABLE_VIDEO_UPLOAD_PIPELINE under FEATURES section. This key must be enabled so that for a course video upload can be enabled from Advanced Settings. By defult video upload menu will not be visible from menu. This is used by content teams so that they can export from OXA and import to EDX to upload videos on AWS S3 so that can be exported and imported into OXA again. This is e required scenario for aloowing video download feature to our customers. Currently we don't support video upload feature. So meanwhile we must allow video upload feature for this temp workaround. If we don't enable video upload menu/feature, when we export course, on edx video upload menu is not visible. So this is a required change. And it is harmless.

@Microsoft/lex 