### PR TITLE
honor course_mode automatic insertion and fixing password issue for MySQL statements

### DIFF
--- a/playbooks/roles/mysql/files/edxapp.sql
+++ b/playbooks/roles/mysql/files/edxapp.sql
@@ -144,3 +144,51 @@ SELECT
   ) LIMIT 1
 );
 
+/*
+ Whenever a new course is created from CMS a row is inserted into course_overviews_courseoverview table.
+ We are defining this trigger so that course_mode for honor is inserted automatically which is required for certification.
+*/
+DROP TRIGGER IF EXISTS course_overviews_coursesoverview_after_insert;
+DELIMITER $$
+CREATE TRIGGER course_overviews_coursesoverview_after_insert
+AFTER INSERT ON 
+course_overviews_courseoverview
+FOR EACH ROW
+BEGIN
+	INSERT INTO course_modes_coursemode
+	(
+course_id, mode_slug, mode_display_name, min_price, currency, expiration_datetime,
+expiration_date, suggested_prices, description, sku, expiration_datetime_is_explicit		
+	)
+	VALUES
+(
+NEW.id, 
+'honor', 
+'honor',
+ 0, 
+'usd', 
+NULL, 
+NULL, 
+0, 
+NULL, 
+NULL,
+0
+);
+END$$
+DELIMITER ;
+
+/*
+ Whenever a a course is deleted from SYSADMIN menu it is deleted from course_overviews_courseoverview table as well. 
+ We are defining this trigger so that course_mode for honor is deleted automatically which is not needed anymore.
+*/
+DROP TRIGGER IF EXISTS course_overviews_courseoverview_after_delete;
+DELIMITER $$
+CREATE TRIGGER course_overviews_courseoverview_after_delete 
+AFTER DELETE ON 
+course_overviews_courseoverview
+FOR EACH ROW
+BEGIN
+	DELETE FROM course_modes_coursemode 
+	WHERE course_modes_coursemode.course_id = old.id;
+END$$
+DELIMITER  ;

--- a/playbooks/roles/mysql/files/edxapp.sql
+++ b/playbooks/roles/mysql/files/edxapp.sql
@@ -178,7 +178,7 @@ END$$
 DELIMITER ;
 
 /*
- Whenever a a course is deleted from SYSADMIN menu it is deleted from course_overviews_courseoverview table as well. 
+ Whenever a course is deleted from SYSADMIN menu it is deleted from course_overviews_courseoverview table as well. 
  We are defining this trigger so that course_mode for honor is deleted automatically which is not needed anymore.
 */
 DROP TRIGGER IF EXISTS course_overviews_courseoverview_after_delete;

--- a/playbooks/roles/mysql/files/oxa_configuration.sh
+++ b/playbooks/roles/mysql/files/oxa_configuration.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT license. See LICENSE file on the project webpage for details.
-mysql edxapp -v -u root < edxapp.sql
+mysql edxapp --host=$1 --user=$2 --password=$3  < edxapp.sql
+
+
 

--- a/playbooks/roles/mysql/tasks/main.yml
+++ b/playbooks/roles/mysql/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Run OXA script
   sudo: yes
-  shell: mysql edxapp -h "{{ EDXAPP_MYSQL_HOST }}" -u "{{ EDXAPP_MYSQL_USER_ADMIN }}" -p"{{ EDXAPP_MYSQL_PASSWORD_ADMIN }}" < edxapp.sql
+  shell: bash oxa_configuration.sh "{{ EDXAPP_MYSQL_HOST }}" "{{ EDXAPP_MYSQL_USER_ADMIN }}" "{{ EDXAPP_MYSQL_PASSWORD_ADMIN }}"
   args:
     chdir: "{{ mysql_files_path }}"
   register: bash


### PR DESCRIPTION
In this PR we addressing 2 issues:
1) Firstly, we are running custom MySQL statements and creating oxamaster user is one of them. These queries are in edxapp.sql file. When called directly in Ansible shell command somehow it fails. So now we pass the EDXAPP_MYSQL_HOST, EDXAPP_MYSQL_USER_ADMIN and EDXAPP_MYSQL_PASSWORD_ADMIN to oxa_configuration.sh script file and using there. This solution is working.

2) Secondly, when a new course created in CMS we had to insert a row into course_mode table for honor mode for certification. We added two triggers to the MySQL that whenever a new course created this row is inserted automatically and deleted automatically when course is deleted from SYSADMIN. The script deletes the triggers first if they exists which makes it re-runnable. Thanks to Mani for the solution.
