### PR TITLE
Adding commit between 2 sql statements for superuser due to dependency

### DIFF
--- a/playbooks/roles/mysql/files/edxapp.sql
+++ b/playbooks/roles/mysql/files/edxapp.sql
@@ -117,7 +117,7 @@ SELECT
     SELECT * FROM auth_user WHERE username='oxamaster'
   ) LIMIT 1
 );
-
+commit;
 INSERT INTO auth_userprofile
 (
   name,


### PR DESCRIPTION
I insert oxamaster user into auth_user table.
Then I insert profile row into auth_userprofile for user oxamaster. 
So this is 2 insert statements but second one has SELECT statement first. It looks like it cannot find it.

Solution:
I will add “commit;” statement after auth_user insert. I think this will solve the issue. The other all statements worked fine since they don’t have any dependency on any other statement in the sql file.
