### PR TITLE
Enable AAD oauth automnatically in ANSIBLE deployment

### DIFF
--- a/config/server-vars.yml
+++ b/config/server-vars.yml
@@ -11,6 +11,11 @@ EDXAPP_SU_PASSWORD: "%%EDXAPP_SU_PASSWORD%%"
 EDXAPP_SU_EMAIL: "%%EDXAPP_SU_EMAIL%%"
 EDXAPP_SU_USERNAME: "%%EDXAPP_SU_USERNAME%%"
 
+# Enable Azure Active Directory OAuth2 Third Party Authentication
+EDXAPP_AAD_CLIENT_ID: "%%EDXAPP_AAD_CLIENT_ID%%"
+EDXAPP_AAD_SECURITY_KEY: "%%EDXAPP_AAD_SECURITY_KEY%%" 
+EDXAPP_AAD_BUTTON_NAME: "%%EDXAPP_AAD_BUTTON_NAME%%"
+
 # Configure third-party auth
 # see: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/
 # see: https://github.com/MSOpenTech/edx-documentation/blob/master/en_us/install_operations/source/configuration/enable_sso.rst
@@ -71,7 +76,7 @@ EDXAPP_SOCIAL_MEDIA_FOOTER_NAMES: [ "linkedin" ]
 
 # see: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/feature_flags/feature_flag_index.html
 EDXAPP_FEATURES:  
-  #ENABLE_THIRD_PARTY_AUTH: "{{ EDXAPP_ENABLE_THIRD_PARTY_AUTH }}"
+  ENABLE_THIRD_PARTY_AUTH: "%%EDXAPP_ENABLE_THIRD_PARTY_AUTH%%"
   #ENABLE_OAUTH2_PROVIDER: "{{ EDXAPP_ENABLE_OAUTH2_PROVIDER }}"
   ENABLE_SYSADMIN_DASHBOARD: true
   ENABLE_INSTRUCTOR_EMAIL: true
@@ -85,7 +90,7 @@ EDXAPP_FEATURES:
   CERTIFICATES_HTML_VIEW: true
   ENABLE_GRADE_DOWNLOADS: true
   ENABLE_VIDEO_UPLOAD_PIPELINE: true
-
+  
 # Comprehensive Theming Configuration
 EDXAPP_COMPREHENSIVE_THEME_DIRS: [ "/edx/app/edxapp/themes" ]
 EDXAPP_ENABLE_COMPREHENSIVE_THEMING: true

--- a/playbooks/roles/mysql/files/oxa_configuration.sh
+++ b/playbooks/roles/mysql/files/oxa_configuration.sh
@@ -3,5 +3,17 @@
 # Licensed under the MIT license. See LICENSE file on the project webpage for details.
 mysql edxapp --host=$1 --user=$2 --password=$3  < edxapp.sql
 
+if [ "$7" == "true" ] || [ "$7" == "True" ]; then
+echo "BEGIN; " > edxapp_aad.sql
+echo "DELETE FROM third_party_auth_oauth2providerconfig where backend_name='azuread-oauth2';" >> edxapp_aad.sql
+echo "INSERT INTO third_party_auth_oauth2providerconfig " >> edxapp_aad.sql
+echo "(change_date,enabled,icon_class,name,secondary,skip_registration_form,skip_email_verification,backend_name,third_party_auth_oauth2providerconfig.key,secret,other_settings,icon_image) " >> edxapp_aad.sql
+echo " VALUES " >> edxapp_aad.sql
+echo "(NOW(),1,'fa-sign-in','$4',0,1,1,'azuread-oauth2','$5','$6','','');" >> edxapp_aad.sql
+echo " COMMIT; " >> edxapp_aad.sql
+
+mysql edxapp --host=$1 --user=$2 --password=$3  < edxapp_aad.sql
+fi
+
 
 

--- a/playbooks/roles/mysql/tasks/main.yml
+++ b/playbooks/roles/mysql/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Run OXA script
   sudo: yes
-  shell: bash oxa_configuration.sh "{{ EDXAPP_MYSQL_HOST }}" "{{ EDXAPP_MYSQL_USER_ADMIN }}" "{{ EDXAPP_MYSQL_PASSWORD_ADMIN }}"
+  shell: bash oxa_configuration.sh "{{ EDXAPP_MYSQL_HOST }}" "{{ EDXAPP_MYSQL_USER_ADMIN }}" "{{ EDXAPP_MYSQL_PASSWORD_ADMIN }}" "{{ EDXAPP_AAD_BUTTON_NAME }}" "{{ EDXAPP_AAD_CLIENT_ID }}" "{{ EDXAPP_AAD_SECURITY_KEY }}" "{{ EDXAPP_ENABLE_THIRD_PARTY_AUTH }}"
   args:
     chdir: "{{ mysql_files_path }}"
   register: bash


### PR DESCRIPTION
We defined these configuration. 
EDXAPP_ENABLE_THIRD_PARTY_AUTH=false
EDXAPP_AAD_CLIENT_ID=""
EDXAPP_AAD_SECURITY_KEY=""
EDXAPP_AAD_BUTTON_NAME=""

Now it inserts the row into third_party_auth_oauth2providerconfig to enable AAD with OAuth2 with the above given credentials.
