### PR TITLE
ENABLE_CSMH_EXTENDED configuration

### DIFF
--- a/config/server-vars.yml
+++ b/config/server-vars.yml
@@ -90,6 +90,7 @@ EDXAPP_FEATURES:
   CERTIFICATES_HTML_VIEW: true
   ENABLE_GRADE_DOWNLOADS: true
   ENABLE_VIDEO_UPLOAD_PIPELINE: true
+  ENABLE_CSMH_EXTENDED: true 
   
 # Comprehensive Theming Configuration
 EDXAPP_COMPREHENSIVE_THEME_DIRS: [ "/edx/app/edxapp/themes" ]


### PR DESCRIPTION
ENABLE_CSMH_EXTENDED configuration is enabled which will write student course mode history (CSMH)  to a separate database for better MYSQL performance as recommended by edx. It will be in edxapp_csmh database and new table has long id instead of int.