### PR TITLE
Changing the default Cli Version

### DIFF
--- a/scripts/Deploy-OxaStamp.ps1
+++ b/scripts/Deploy-OxaStamp.ps1
@@ -122,7 +122,7 @@ Param(
         [Parameter(Mandatory=$false)][string]$EdxAppSuperUserPassword="",
         [Parameter(Mandatory=$false)][string]$EdxAppSuperUserEmail="",
 
-        [Parameter(Mandatory=$false)][string][ValidateSet("1","2")]$AzureCliVersion="2",
+        [Parameter(Mandatory=$false)][string][ValidateSet("1","2")]$AzureCliVersion="1",
         [Parameter(Mandatory=$false)][string]$MemcacheServer="10.0.0.16"
      )
 


### PR DESCRIPTION
This PR changes the default AzureCliVersion to 1.0 instead of 2.0.

In our partner documentation, we have referenced the use of Azure Cli 1.0. Changing the default to 2.0 adds additional overhead for partner implementation. So instead of defaulting to Azure Cli 2.0, we now default to 1.0 but allow the user to explicitly specify the use of Azure Cli 2.0 via command line parameter at deployment-time