### PR TITLE
Updating default Service Account Password

### DIFF
--- a/scripts/Deploy-OxaStamp.ps1
+++ b/scripts/Deploy-OxaStamp.ps1
@@ -113,7 +113,7 @@ Param(
         [Parameter(Mandatory=$false)][string]$SmtpAuthenticationUser="",
         [Parameter(Mandatory=$false)][string]$SmtpAuthenticationUserPassword="",
 
-        [Parameter(Mandatory=$false)][string]$ServiceAccountPassword="=crq+4L5QFrMCIKJaVazBWisd0fMJR",
+        [Parameter(Mandatory=$false)][string]$ServiceAccountPassword="5QFrMCIKJaVazBWisd0fMJR",
 
         [Parameter(Mandatory=$false)][string]$PlatformName="Contoso Learning",
         [Parameter(Mandatory=$false)][string]$PlatformEmailAddress="",


### PR DESCRIPTION
The default service account password specified in the deployment script breaks the forum connection string. In the partner scenario (for those using the defaults), this prevents the creation of the edxapp super user.