### PR TITLE
 Enabling support for Third-Party SMTP Relay

### DIFF
--- a/templates/stamp/run-customizations.sh
+++ b/templates/stamp/run-customizations.sh
@@ -174,7 +174,7 @@ parse_args()
             -c) # Cloud Name
                 CLOUDNAME="${arg_value}"
                 ;;
-            -u) # OS Admin User Name
+            -u| --admin-user) # OS Admin User Name
                 OS_ADMIN_USERNAME="${arg_value}"
                 ;;
             -i) # Custom script relative path
@@ -191,9 +191,6 @@ parse_args()
                     help
                     exit 2
                 fi
-                ;;
-            -u|--admin-user)
-                OS_ADMIN_USERNAME="${arg_value}"
                 ;;
             --monitoring-cluster)
                 MONITORING_CLUSTER_NAME="${arg_value}"
@@ -607,7 +604,7 @@ MACHINE_ROLE=$(get_machine_role)
 log "${HOSTNAME} has been identified as a member of the '${MACHINE_ROLE}' role"
 
 # Pre-Requisite: Setup Mailer (this is necessary for notification)
-install-mailer $SMTP_SERVER $SMTP_SERVER_PORT $SMTP_AUTH_USER $SMTP_AUTH_USER_PASSWORD $CLUSTER_ADMIN_EMAIL
+install-mailer $SMTP_SERVER $SMTP_SERVER_PORT $SMTP_AUTH_USER $SMTP_AUTH_USER_PASSWORD $CLUSTER_ADMIN_EMAIL $OS_ADMIN_USERNAME
 exit_on_error "Configuring the mailer failed"
 
 # 1. Setup Tools

--- a/templates/stamp/utilities.sh
+++ b/templates/stamp/utilities.sh
@@ -772,14 +772,14 @@ EOF
     tee $ALIAS_CONFIG_FILE > /dev/null <<EOF
 root:{CLUSTER_ADMIN_EMAIL}:{SMTP_SERVER}:{SMTP_SERVER_PORT}
 postmaster:{CLUSTER_ADMIN_EMAIL}:{SMTP_SERVER}:{SMTP_SERVER_PORT}
-{OSADMIN_USERNAME}:{CLUSTER_ADMIN_EMAIL}:{SMTP_SERVER}:{SMTP_SERVER_PORT}
+{OS_ADMIN_USERNAME}:{CLUSTER_ADMIN_EMAIL}:{SMTP_SERVER}:{SMTP_SERVER_PORT}
 EOF
     # replace the place holders
     log "Populating Aliases with appropriate values"
     sed -i "s/{CLUSTER_ADMIN_EMAIL}/${CLUSTER_ADMIN_EMAIL}/I" $ALIAS_CONFIG_FILE
     sed -i "s/{SMTP_SERVER}/${SMTP_SERVER}/I" $ALIAS_CONFIG_FILE
     sed -i "s/{SMTP_SERVER_PORT}/${SMTP_SERVER_PORT}/I" $ALIAS_CONFIG_FILE
-    sed -i "s/{OSADMIN_USERNAME}/${os_admin_username}/I" $ALIAS_CONFIG_FILE
+    sed -i "s/{OS_ADMIN_USERNAME}/${os_admin_username}/I" $ALIAS_CONFIG_FILE
 
     log "Completed configuring the mailer"
 }


### PR DESCRIPTION
A number of partners have had issues with getting email notification from the OXA cluster using their third-party SMTP relays. These relays seem to reject emails sent from the OXA cluster. This change makes additional configuration updates to allow cluster notifications to be sent via third-party SMTP relay servers. 

This change specifically supports O365 & Google Email accounts with SMTP support.