### PR TITLE
Fix check for custom images when updating theme

### DIFF
--- a/playbooks/roles/edxapp/files/update_theme.sh
+++ b/playbooks/roles/edxapp/files/update_theme.sh
@@ -23,7 +23,9 @@ sudo git clone $EDX_THEME_REPO $dir_themes -b $THEME_BRANCH
 
 # todo:100627 this doesn't work on onebox installations (fullstack and devstack) which don't use oxa-tools-config
 # Generalizing - we only need to do this when there are images that should be copied.
-if [[ -f "/oxa/oxa-tools-config/env/${ENVIRONMENT}/*.png" ]]; then
+custom_images=( "/oxa/oxa-tools-config/env/${ENVIRONMENT}/*.png" )
+
+if (( ${#custom_images[@]} )); then
     for i in `ls -d1 $dir_themes/*/lms/static/images`; do
         sudo cp /oxa/oxa-tools-config/env/$ENVIRONMENT/*.png $i;
     done

--- a/playbooks/roles/edxapp/files/update_theme.sh
+++ b/playbooks/roles/edxapp/files/update_theme.sh
@@ -23,9 +23,9 @@ sudo git clone $EDX_THEME_REPO $dir_themes -b $THEME_BRANCH
 
 # todo:100627 this doesn't work on onebox installations (fullstack and devstack) which don't use oxa-tools-config
 # Generalizing - we only need to do this when there are images that should be copied.
-custom_images=( "/oxa/oxa-tools-config/env/${ENVIRONMENT}/*.png" )
+custom_image_count=`ls /oxa/oxa-tools-config/env/${ENVIRONMENT}/*.png 2>/dev/null | wc -w`
 
-if (( ${#custom_images[@]} )); then
+if (( $(echo "$custom_image_count > 0" | bc -l) )); then
     for i in `ls -d1 $dir_themes/*/lms/static/images`; do
         sudo cp /oxa/oxa-tools-config/env/$ENVIRONMENT/*.png $i;
     done

--- a/playbooks/roles/edxapp/files/update_theme.sh
+++ b/playbooks/roles/edxapp/files/update_theme.sh
@@ -21,8 +21,9 @@ cd $dir_edxapp
 # Download comprehensive theming from github to folder $dir_themes/comprehensive 
 sudo git clone $EDX_THEME_REPO $dir_themes -b $THEME_BRANCH
 
-# todo:100627 this doesn't work on onebox installations (fullstack and devstack) which don't use oxa-tools-config
-# Generalizing - we only need to do this when there are images that should be copied.
+# Generalizing - Applying custom images isn't applicable for all scenarios. 
+# Therefore, it is necessary to first check if custom images are available 
+# before attempting to copy them.
 custom_image_count=`ls /oxa/oxa-tools-config/env/${ENVIRONMENT}/*.png 2>/dev/null | wc -w`
 
 if (( $(echo "$custom_image_count > 0" | bc -l) )); then


### PR DESCRIPTION
#### What does this PR do? Please provide some context
This PR changes the check for custom images to be copied before applying theme.

#### Where should the reviewer start?
The change

#### How can this be manually tested? (brief repro steps)
Pull out the code snippet and run it against your fullstack/stamp deployment.

#### What are the relevant TFS items? (list id numbers)
#103406

#### Definition of done:
- [x] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage

#### Reminders BEFORE merging
1. Get at least two approvals
1. If you're merging from a feature branch into the development branch then "flatten" or "squash" commits
1. If merging from the development branch into master (or porting changes from upstream) then use github's UI to get review feedback, but use the git command line interface to complete the actual merge.

#### Reminders AFTER merging
1. Delete the remote feature branch
1. Resolve relevant TFS items
1. (reverse merge) If you merged from the development branch into master then check to see if there are any changes in master that can be merged down to the development branch (like hotfixes, etc). In this case, use github's UI for feedback and the git command line interface for the actual merge.

[//]: # ( todo: If you merged into development branch then verify change in our "rolling deployment" environment. Then notify stakeholders interested in or involved with the change )

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
