### PR TITLE
removing  "courses.microsoft.com" related site configurations

### DIFF
--- a/playbooks/roles/mysql/files/edxapp.sql
+++ b/playbooks/roles/mysql/files/edxapp.sql
@@ -104,18 +104,18 @@ VALUES
 
 /* Insert an entry so that new site is enabled with a domain name */
 
-INSERT INTO django_site (domain,name) VALUES ('courses.microsoft.com','courses');
+/* INSERT INTO django_site (domain,name) VALUES ('courses.microsoft.com','courses'); 
 
-/* Updating the siteconfigurations for the existing site */
+ Updating the siteconfigurations for the existing site 
 
-UPDATE site_configuration_siteconfiguration SET `values` = '{"course_org_filter":"Microsoft","ENABLE_THIRD_PARTY_AUTH":false,"LMS_BASE":"openedx.microsoft.com"}' WHERE `site_id` = 1;
+ UPDATE site_configuration_siteconfiguration SET `values` = '{"course_org_filter":"Microsoft","ENABLE_THIRD_PARTY_AUTH":false,"LMS_BASE":"openedx.microsoft.com"}' WHERE `site_id` = 1;
 
-/*Insert siteconfigurations for courses site */
+Insert siteconfigurations for courses site 
 
-INSERT INTO `site_configuration_siteconfiguration` (`site_id`, `values`,`enabled`) VALUES (2,'{"course_org_filter":"ELMS","ENABLE_THIRD_PARTY_AUTH":"true","ENFORCE_PASSWORD_POLICY":"false","SITE_NAME":"courses.microsoft.com","LMS_BASE":"courses.microsoft.com"}',1); 
+ INSERT INTO `site_configuration_siteconfiguration` (`site_id`, `values`,`enabled`) VALUES (2,'{"course_org_filter":"ELMS","ENABLE_THIRD_PARTY_AUTH":"true","ENFORCE_PASSWORD_POLICY":"false","SITE_NAME":"courses.microsoft.com","LMS_BASE":"courses.microsoft.com"}',1); 
 
-/*Insert an entry so that courses site uses different theming */
+Insert an entry so that courses site uses different theming 
 
 INSERT INTO theming_sitetheme (theme_dir_name,site_id) VALUES ('courses',2);
 
-commit;
+commit; */

--- a/playbooks/roles/mysql/files/edxapp.sql
+++ b/playbooks/roles/mysql/files/edxapp.sql
@@ -102,21 +102,3 @@ VALUES
   1
 );
 commit;
-
-/* Insert an entry so that new site is enabled with a domain name */
-
-/* INSERT INTO django_site (domain,name) VALUES ('courses.microsoft.com','courses'); 
-
- Updating the siteconfigurations for the existing site 
-
- UPDATE site_configuration_siteconfiguration SET `values` = '{"course_org_filter":"Microsoft","ENABLE_THIRD_PARTY_AUTH":false,"LMS_BASE":"openedx.microsoft.com"}' WHERE `site_id` = 1;
-
-Insert siteconfigurations for courses site 
-
- INSERT INTO `site_configuration_siteconfiguration` (`site_id`, `values`,`enabled`) VALUES (2,'{"course_org_filter":"ELMS","ENABLE_THIRD_PARTY_AUTH":"true","ENFORCE_PASSWORD_POLICY":"false","SITE_NAME":"courses.microsoft.com","LMS_BASE":"courses.microsoft.com"}',1); 
-
-Insert an entry so that courses site uses different theming 
-
-INSERT INTO theming_sitetheme (theme_dir_name,site_id) VALUES ('courses',2);
-
-*/

--- a/playbooks/roles/mysql/files/edxapp.sql
+++ b/playbooks/roles/mysql/files/edxapp.sql
@@ -101,6 +101,7 @@ VALUES
   1,
   1
 );
+commit;
 
 /* Insert an entry so that new site is enabled with a domain name */
 
@@ -118,4 +119,4 @@ Insert an entry so that courses site uses different theming
 
 INSERT INTO theming_sitetheme (theme_dir_name,site_id) VALUES ('courses',2);
 
-commit; */
+*/


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Removing default site_configurations 
Note: This edxapp.sql file is adding "courses.microsoft.com" site related configurations for all the the deployment. we don't want this to be added in partner's deployment.

#### Where should the reviewer start?
Before: a row will be added in site_configurations by default for all the deployments
After: nothing will be added by default in admin panel.
#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
Before: we can see a row is added in site_configuration table
After: nothing is added by default
#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
