### PR TITLE
reverting the exit on fail option

### DIFF
--- a/playbooks/roles/edxapp/files/create_superuser.sh
+++ b/playbooks/roles/edxapp/files/create_superuser.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 # Licensed under the MIT license. See LICENSE file on the project webpage for details.
 
-set -ex
+set -x
 
 # collect the input parameters for easy identification/reference
 edxapp_superuser_password=$1


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Reverts the exit on fail option from the create_superuser.sh. That is causing BVT/INT deployments where continuous deployment is enabled as the user already exists. The option was recently added. I have checked the previous successful logs of BVT, they all have failure logs in creating the oxamaster account (as it already exists, since BVT is not a brand new deployment) but continue to execute. The better solution would be to actually check if the account exist first, but for a quick fix I am just reverting the change.

#### Where should the reviewer start?
create_superuser.sh
#### How can this be manually tested? (brief repro steps and corpnet-URL with change)

#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
