### PR TITLE
clone theme repo earlier in deployment

### DIFF
--- a/playbooks/roles/edxapp/files/update_theme.sh
+++ b/playbooks/roles/edxapp/files/update_theme.sh
@@ -64,8 +64,9 @@ copy_images()
 src_utils
 theme_path=$(get_theme_directory)
 
+#todo: consider reducing duplication by invoking clone_theme_dir directly
+
 # Download comprehensive theming from github
-clean_repository $theme_path
 sync_repo $EDX_THEME_REPO $THEME_BRANCH $theme_path
 
 copy_images

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -467,7 +467,7 @@ edx_installation_playbook()
     exit_on_error "Single VM instance of EDX has a hard requirement on systemd and its systemctl functionality"
 
     EDXAPP_COMPREHENSIVE_THEME_DIR=`echo $EDXAPP_COMPREHENSIVE_THEME_DIRS | tr -d [ | tr -d ] | tr -d " " | tr -d \"`
-    make_theme_dir "$EDXAPP_COMPREHENSIVE_THEME_DIR" "$EDX_PLATFORM_PUBLIC_GITHUB_PROJECTNAME"
+    clone_theme_dir "$EDX_PLATFORM_PUBLIC_GITHUB_PROJECTNAME" "$EDX_THEME_REPO" "$EDX_THEME_PUBLIC_GITHUB_PROJECTBRANCH" "$EDXAPP_COMPREHENSIVE_THEME_DIR"
 
     # We've been experiencing intermittent failures on ficus. Simply retrying
     # mitigates the problem, but we should solve the underlying cause(s) soon.

--- a/templates/stamp/run-customizations.sh
+++ b/templates/stamp/run-customizations.sh
@@ -705,7 +705,8 @@ exit_on_error "Configuring the mailer failed"
 install-tools
 
 if [[ "$MACHINE_ROLE" == "jumpbox" ]] || [[ "$MACHINE_ROLE" == "vmss" ]] ; then
-    make_theme_dir "$EDXAPP_COMPREHENSIVE_THEME_DIR" "$EDX_PLATFORM_PUBLIC_GITHUB_PROJECTNAME"
+    EDX_THEME_REPO=$(get_github_url ${EDX_THEME_PUBLIC_GITHUB_ACCOUNTNAME} ${EDX_THEME_PUBLIC_GITHUB_PROJECTNAME})
+    clone_theme_dir "$EDX_PLATFORM_PUBLIC_GITHUB_PROJECTNAME" "$EDX_THEME_REPO" "$EDX_THEME_PUBLIC_GITHUB_PROJECTBRANCH" "$EDXAPP_COMPREHENSIVE_THEME_DIR"
 fi
 
 # 2. Install & Configure the infrastructure & EdX applications

--- a/templates/stamp/utilities.sh
+++ b/templates/stamp/utilities.sh
@@ -655,21 +655,24 @@ cherry_pick_wrapper()
 #############################################################################
 # Create theme directory before edx playbook
 #############################################################################
-make_theme_dir()
+clone_theme_dir()
 {
-    EDXAPP_COMPREHENSIVE_THEME_DIR="$1"
-    EDX_PLATFORM_PUBLIC_GITHUB_PROJECTNAME="$2"
+    EDX_PLATFORM_PUBLIC_GITHUB_PROJECTNAME="$1"
+    EDX_THEME_REPO="$2"
+    EDX_THEME_PUBLIC_GITHUB_PROJECTBRANCH="$3"
+    EDXAPP_COMPREHENSIVE_THEME_DIR="$4"
 
     # When the comprehensive theming dirs is specified, edxapp:migrate task fails with :  ImproperlyConfigured: COMPREHENSIVE_THEME_DIRS
-    # As an interim mitigation, create the folder if the path specified is not under the edx-platform directory (where the default themes directory is)
-    if [[ -n "${EDXAPP_COMPREHENSIVE_THEME_DIR}" ]] && [[ ! -d "${EDXAPP_COMPREHENSIVE_THEME_DIR}" ]] ; then
-        # now check if the path specified is within the default edx-platform/themes directory
+    # because the theme folder doesn't exist on disk. Therefore, we create the theme folder by cloning the theme repo.
+    if [[ -n "${EDXAPP_COMPREHENSIVE_THEME_DIR}" ]] ; then
+        # Now we check if the path specified is within the default edx-platform/themes directory (which is already guarenteed to exist)
         if [[ "${EDXAPP_COMPREHENSIVE_THEME_DIR}" == *"${EDX_PLATFORM_PUBLIC_GITHUB_PROJECTNAME}"* ]] ; then
             log "'${EDXAPP_COMPREHENSIVE_THEME_DIR}' falls under the default theme directory. Skipping creation since the edx-platform clone will create it."
         else
-            log "Creating comprehensive themeing directory at ${EDXAPP_COMPREHENSIVE_THEME_DIR}"
-            mkdir -p "${EDXAPP_COMPREHENSIVE_THEME_DIR}"
+            log "Creating comprehensive theming directory at ${EDXAPP_COMPREHENSIVE_THEME_DIR}"
+            sync_repo $EDX_THEME_REPO $EDX_THEME_PUBLIC_GITHUB_PROJECTBRANCH $EDXAPP_COMPREHENSIVE_THEME_DIR
             chown -R edxapp:edxapp "${EDXAPP_COMPREHENSIVE_THEME_DIR}"
+            sudo chmod -R u+rw "${EDXAPP_COMPREHENSIVE_THEME_DIR}"
         fi
     fi
 }


### PR DESCRIPTION
#### What does this PR do? Please provide some context

We identified a bug with deploying edx using vagrant. The issue is caused by how and when we setup the theming directory. It's likely that this bug has other ways of manifesting itself outside of vagrant.
The fix is to simply clone the theming repository earlier in the deployment procedure. This allows the edx deployment steps to "see" the theming directory. It also means that we will not need to delete the directory (which can fail) before doing the git clone.

#### Where should the reviewer start?

n/a. short review.

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)

deploy onebox or STAMP

#### What are the relevant TFS items? (list id numbers)

109551

#### Definition of done:
- [x] Title of the pull request is clear and informative
- [x] Add pull request hyperlink to relevant TFS items
- [x] For large or complex change: schedule an in-person review session
- [x] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
