### PR TITLE
removing a test SKU due to external, breaking changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,9 @@ workflows:
   version: 2
   all:
     jobs:
+    # - FsEdxMaster #todo: this SKU generally succeeeds, but the total runtime exceeds CircleCi's timeout
       - FsGink
-      - DsEdxMaster
+    # - DsEdxMaster #todo: https://github.com/edx/configuration/pull/4492/ removed playbooks/vagrant-devstack.yml
       - DsGink
       - DsDevFic
       - DsReleaseFic

--- a/onebox.sh
+++ b/onebox.sh
@@ -221,10 +221,11 @@ set_dynamic_vars()
 
 test_args()
 {
+    echo -e "\033[1;36m"
+
+    echo -e "\n TEMPLATE_TYPE is set to $TEMPLATE_TYPE"
     if [[ $TEMPLATE_TYPE != $FS ]] && [[ $TEMPLATE_TYPE != $DS ]] ; then
         set +x
-        echo -e "\033[1;36m"
-        echo -e "\n TEMPLATE_TYPE is set to $TEMPLATE_TYPE"
         echo -e " but should be $FS or $DS."
         echo -e " Use the -r param argument.\n"
         echo -e '\033[0m'
@@ -234,17 +235,27 @@ test_args()
     echo -e "\n BRANCH_VERSIONS is set to $BRANCH_VERSIONS"
     case "$BRANCH_VERSIONS" in
         stable|release|edge|edx_f|edx_g|edx_master)
-            echo ""
+            echo -e ""
         ;;
         *)
             set +x
-            echo -e "\033[1;36m"
-            echo -e " but should be stable OR release OR edge OR edx .\n"
+            echo -e " but should be stable OR release OR edge OR edx_* .\n"
             echo -e " Use the -b param argument.\n"
             echo -e '\033[0m'
             exit 1
         ;;
     esac
+
+    if [[ $TEMPLATE_TYPE == $DS ]] && [[ $BRANCH_VERSIONS == edx_master ]] ; then
+        set +x
+        echo -e " this SKU cannot be deployed because"
+        echo -e " https://github.com/edx/configuration/pull/4492/"
+        echo -e " removed playbooks/vagrant-devstack.yml \n"
+        echo -e '\033[0m'
+        exit 1
+    fi
+
+    echo -e '\033[0m'
 }
 
 ##########################


### PR DESCRIPTION
#### What does this PR do? Please provide some context

There are tests we run for every PR into our oxa/master.fic . One of these tests (deploying devstack using the latest upstream edx master) will fail due to breaking changes in openedx. The SKU is not essential so this change disables it with a comment explaining why. We'll also "fail fast" if the particular installation is attempted outside of automating testing.

Note: The "breaking" change is https://github.com/edx/configuration/pull/4492/ . We should adopt the modern containerized devstack as part of our move to Hawthorne.

#### Where should the reviewer start?

n/a. simple review

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)

Automating testing will continue succeeeding

#### What are the relevant TFS items? (list id numbers)

n/a. test fix required for future merges into oxa/master.fic

#### Definition of done:
- [x] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [x] For large or complex change: schedule an in-person review session
- [x] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
